### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/jaswdr/dolarhoje/security/code-scanning/1](https://github.com/jaswdr/dolarhoje/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow. Since the workflow only builds and tests the code, it does not require write permissions. We will set `contents: read` to allow the workflow to read the repository contents, which is necessary for the `actions/checkout` step.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
